### PR TITLE
Fix launch music player on headset connect on reboot

### DIFF
--- a/services/core/java/com/android/server/audio/AudioService.java
+++ b/services/core/java/com/android/server/audio/AudioService.java
@@ -676,6 +676,9 @@ public class AudioService extends IAudioService.Stub {
         Vibrator vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
         mHasVibrator = vibrator == null ? false : vibrator.hasVibrator();
 
+        mLaunchPlayer = Settings.System.getIntForUser(mContext.getContentResolver(),
+                Settings.System.HEADSET_CONNECT_PLAYER, 0, UserHandle.USER_CURRENT);
+
         // Initialize volume
         int maxVolume = SystemProperties.getInt("ro.config.vc_call_vol_steps",
                 MAX_STREAM_VOLUME[AudioSystem.STREAM_VOICE_CALL]);


### PR DESCRIPTION
* Feature would appear as enabled on reboot, but when the headset is connected - no action takes place.

Change-Id: Ie6b109c6b366ce3e025fbbd8d2fc0a4004370e93